### PR TITLE
Monitoring and feedback

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,12 +30,14 @@ jobs:
       env:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+        DASHBOARD_PASSWORD: ${{ secrets.DASHBOARD_PASSWORD }}
       run: echo "Environment variables OPENAI_API_KEY and PINECONE_API_KEY are set"
 
     - name: Run tests with coverage
       env:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+        DASHBOARD_PASSWORD: ${{ secrets.DASHBOARD_PASSWORD }}
       run: |
         pytest --cov=./ --cov-report=xml
 
@@ -61,6 +63,7 @@ jobs:
         run: |
           docker run --rm -e OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }} \
                         -e PINECONE_API_KEY=${{ secrets.PINECONE_API_KEY }} \
+                        -e DASHBOARD_PASSWORD=${{ secrets.DASHBOARD_PASSWORD }} \
                         ghcr.io/fizcochat/${GITHUB_REPOSITORY,,}:latest pytest
 
       - name: Tag Docker Image
@@ -90,4 +93,5 @@ jobs:
           docker run -d --name rag-chatbot -p 8501:8501 \
             -e OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }} \
             -e PINECONE_API_KEY=${{ secrets.PINECONE_API_KEY }} \
+            -e DASHBOARD_PASSWORD=${{ secrets.DASHBOARD_PASSWORD }} \
             ghcr.io/fizcochat/${GITHUB_REPOSITORY,,}:latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,16 @@
-.env
+# Virtual environment
 env/
 venv/
 venv-rag/
-__pycache__
+
+# Python cache
+__pycache__/
+*.py[cod]
+*.so
 .pytest_cache/
+
+# Environment variables
+.env
 
 # Docker
 .docker/
@@ -12,3 +19,7 @@ docker-compose.override.yml
 # Keep data_documents folder but ignore its contents
 data_documents/*
 !data_documents/.gitkeep
+
+# Logs (SQLite DB)
+monitor/logs/logs.db
+!monitor/logs/.gitkeep

--- a/main.py
+++ b/main.py
@@ -11,8 +11,14 @@ from langchain.prompts import (
     ChatPromptTemplate,
     MessagesPlaceholder
 )
-from monitor.db_logger import init_db, log_event
+from monitor.db_logger import init_db, log_event, get_all_logs, export_logs_to_csv
 import dotenv
+import pandas as pd
+import altair as alt
+import time
+from io import StringIO
+from streamlit_autorefresh import st_autorefresh
+
 
 dotenv.load_dotenv()
 
@@ -65,133 +71,234 @@ if not OPENAI_API_KEY or not PINECONE_API_KEY:
     st.error("Please set up your API keys in the .env file")
     st.stop()
 
-# Initialize services with environment variables
-vectorstore, client = initialize_services(OPENAI_API_KEY, PINECONE_API_KEY)
+# Initialize the database
+init_db()
 
-# Remove the dropdown and set a fixed model
-llm = ChatOpenAI(model_name="gpt-3.5-turbo", openai_api_key=OPENAI_API_KEY)
+query_params = st.query_params
+page = query_params.get("page", "chat")  # default to chat
 
-if 'responses' not in st.session_state:
-     st.session_state['responses'] = ["How can I assist you?"]
+if page == "chat":
+    # Initialize services with environment variables
+    vectorstore, client = initialize_services(OPENAI_API_KEY, PINECONE_API_KEY)
 
-if 'requests' not in st.session_state:
-    st.session_state['requests'] = []
+    # Remove the dropdown and set a fixed model
+    llm = ChatOpenAI(model_name="gpt-3.5-turbo", openai_api_key=OPENAI_API_KEY)
 
-if 'buffer_memory' not in st.session_state:
-    st.session_state.buffer_memory = ConversationBufferWindowMemory(k=3, return_messages=True)
+    if 'responses' not in st.session_state:
+        st.session_state['responses'] = ["How can I assist you?"]
 
-if 'pending_feedback' not in st.session_state:
-    st.session_state['pending_feedback'] = None
+    if 'requests' not in st.session_state:
+        st.session_state['requests'] = []
+
+    if 'buffer_memory' not in st.session_state:
+        st.session_state.buffer_memory = ConversationBufferWindowMemory(k=3, return_messages=True)
+
+    if 'pending_feedback' not in st.session_state:
+        st.session_state['pending_feedback'] = None
 
 
-system_msg_template = SystemMessagePromptTemplate.from_template(template="""
-                                                                
-**Never mention that your responses are based on documents, data, or retrieved information. Present all answers as direct and authoritative.** 
-You are **Fisco-Chat**, the AI assistant for **Fiscozen**, a digital platform that simplifies VAT management for freelancers and sole proprietors in Italy. Your primary goal is to provide users with accurate and efficient tax-related assistance by retrieving information from the provided documentation before generating a response. Additionally, you serve as a bridge between:
-- **AI-based assistance** (answering questions directly when the provided documents contain the necessary information),
-- **CS Consultants** (for general customer support beyond your knowledge), and
-- **Tax Advisors** (for complex tax matters requiring personalized expertise).
-                                                                
-**Never mention that your responses are based on documents, data, or retrieved information. Present all answers as direct and authoritative.** 
-                                       
-**Response Workflow:**
-1. **Check Documentation First**
-   - Before answering, always search the provided documentation for relevant information.
-   - If the answer is found, summarize it clearly and concisely.
-   - If the answer is partially found, provide the available information and suggest further steps.
+    system_msg_template = SystemMessagePromptTemplate.from_template(template="""
+                                                                    
+    **Never mention that your responses are based on documents, data, or retrieved information. Present all answers as direct and authoritative.** 
+    You are **Fisco-Chat**, the AI assistant for **Fiscozen**, a digital platform that simplifies VAT management for freelancers and sole proprietors in Italy. Your primary goal is to provide users with accurate and efficient tax-related assistance by retrieving information from the provided documentation before generating a response. Additionally, you serve as a bridge between:
+    - **AI-based assistance** (answering questions directly when the provided documents contain the necessary information),
+    - **CS Consultants** (for general customer support beyond your knowledge), and
+    - **Tax Advisors** (for complex tax matters requiring personalized expertise).
+                                                                    
+    **Never mention that your responses are based on documents, data, or retrieved information. Present all answers as direct and authoritative.** 
+                                        
+    **Response Workflow:**
+    1. **Check Documentation First**
+    - Before answering, always search the provided documentation for relevant information.
+    - If the answer is found, summarize it clearly and concisely.
+    - If the answer is partially found, provide the available information and suggest further steps.
 
-2. **Determine the Best Course of Action**
-   - If the user's question is fully covered in the documentation, respond confidently with the answer.
-   - If the question is outside the scope of the documentation or requires case-specific advice:
-     - **For general support (e.g., account issues, service-related questions):** Suggest redirecting to a **Fiscozen Customer Success Consultant**.
-     - **For tax-specific advice that requires a professional opinion:** Suggest scheduling an appointment with a **Fiscozen Tax Advisor** and provide instructions to do so.
-   - **If the user explicitly requests to speak with a human (CS Consultant or Tax Advisor), immediately suggest the appropriate redirection** without attempting to resolve the issue further.
+    2. **Determine the Best Course of Action**
+    - If the user's question is fully covered in the documentation, respond confidently with the answer.
+    - If the question is outside the scope of the documentation or requires case-specific advice:
+        - **For general support (e.g., account issues, service-related questions):** Suggest redirecting to a **Fiscozen Customer Success Consultant**.
+        - **For tax-specific advice that requires a professional opinion:** Suggest scheduling an appointment with a **Fiscozen Tax Advisor** and provide instructions to do so.
+    - **If the user explicitly requests to speak with a human (CS Consultant or Tax Advisor), immediately suggest the appropriate redirection** without attempting to resolve the issue further.
 
-**Tone & Interaction Guidelines:**
-- Maintain a **professional, clear, and friendly** tone. 
-- Be **precise and concise** in your responses—users appreciate efficiency.
-- Use simple language where possible to make complex tax topics easy to understand.
-- If redirecting to a consultant or advisor, explain **why** the transfer is necessary
-- **Never mention that your responses are based on documents, data, or retrieved information. Present all answers as direct and authoritative.** 
+    **Tone & Interaction Guidelines:**
+    - Maintain a **professional, clear, and friendly** tone. 
+    - Be **precise and concise** in your responses—users appreciate efficiency.
+    - Use simple language where possible to make complex tax topics easy to understand.
+    - If redirecting to a consultant or advisor, explain **why** the transfer is necessary
+    - **Never mention that your responses are based on documents, data, or retrieved information. Present all answers as direct and authoritative.** 
 
-**Limitations & Boundaries:**
-- Do not make assumptions beyond the provided documentation.
-- Do not offer legal, financial, or tax advice beyond the scope of Fiscozen's services.
-- If uncertain, guide the user toward professional assistance rather than providing speculative answers.
-""")
+    **Limitations & Boundaries:**
+    - Do not make assumptions beyond the provided documentation.
+    - Do not offer legal, financial, or tax advice beyond the scope of Fiscozen's services.
+    - If uncertain, guide the user toward professional assistance rather than providing speculative answers.
+    """)
 
-human_msg_template = HumanMessagePromptTemplate.from_template(template="{input}")
+    human_msg_template = HumanMessagePromptTemplate.from_template(template="{input}")
 
-prompt_template = ChatPromptTemplate.from_messages([system_msg_template, MessagesPlaceholder(variable_name="history"), human_msg_template])
+    prompt_template = ChatPromptTemplate.from_messages([system_msg_template, MessagesPlaceholder(variable_name="history"), human_msg_template])
 
-conversation = ConversationChain(memory=st.session_state.buffer_memory, prompt=prompt_template, llm=llm, verbose=True)
+    conversation = ConversationChain(memory=st.session_state.buffer_memory, prompt=prompt_template, llm=llm, verbose=True)
 
-response_container = st.container()
-textcontainer = st.container()
+    response_container = st.container()
+    textcontainer = st.container()
 
-with textcontainer:
-    query = st.chat_input("Type here...")
-    if query:
-        if st.session_state.get('pending_feedback'):
-            fb = st.session_state.pop('pending_feedback')
-            log_event("feedback", query=fb['query'], response=fb['response'], feedback=fb['feedback'])
+    with textcontainer:
+        query = st.chat_input("Type here...")
+        if query:
+            if st.session_state.get('pending_feedback'):
+                fb = st.session_state.pop('pending_feedback')
+                log_event("feedback", query=fb['query'], response=fb['response'], feedback=fb['feedback'])
 
-        with st.spinner("Typing..."):
-            # these are to implement later but I added them now so I dont have to rechange the dashboard later
-            log_event("advisor_request", query=query)
-            log_event("out_of_scope", query=query)
+            with st.spinner("Typing..."):
+                start_time = time.time()
+                # these are to implement later but I added them now so I dont have to rechange the dashboard later
+                log_event("advisor_request", query=query)
+                log_event("out_of_scope", query=query)
+                
+                conversation_string = get_conversation_string()
+                refined_query = query_refiner(client, conversation_string, query)
+                print("\nRefined Query:", refined_query)
+                context = find_match(vectorstore, refined_query)
+                response = conversation.predict(input=f"Context:\n {context} \n\n Query:\n{query}")
+                duration = time.time() - start_time
+                log_event("answered", query=query, response=response)
+                log_event("perf", query=query, response_time=duration)
+                st.session_state['pending_feedback'] = {
+                    "query": query,
+                    "response": response,
+                    "feedback": None
+                }
+
+            st.session_state.requests.append(query)
+            st.session_state.responses.append(response)
+            st.rerun()
+
+    with response_container:
+        if st.session_state['responses']:
+            for i in range(len(st.session_state['responses'])):
+                message(st.session_state['responses'][i], 
+                    avatar_style="no-avatar",
+                    key=str(i))
+                if i < len(st.session_state['requests']):
+                    message(st.session_state["requests"][i], 
+                        is_user=True,
+                        avatar_style="no-avatar",
+                        key=str(i) + '_user')
             
-            conversation_string = get_conversation_string()
-            refined_query = query_refiner(client, conversation_string, query)
-            print("\nRefined Query:", refined_query)
-            context = find_match(vectorstore, refined_query)
-            response = conversation.predict(input=f"Context:\n {context} \n\n Query:\n{query}")
-            log_event("answered", query=query, response=response)
-            st.session_state['pending_feedback'] = {
-                "query": query,
-                "response": response,
-                "feedback": None
-            }
+            # Show feedback only after the latest assistant message
+            last_idx = len(st.session_state['responses']) - 1
+            last_response = st.session_state['responses'][last_idx]
+            last_query = st.session_state['requests'][last_idx] if last_idx < len(st.session_state['requests']) else ""
 
-        st.session_state.requests.append(query)
-        st.session_state.responses.append(response)
-        st.rerun()
+            feedback_key = f"feedback_{last_idx}"
+            feedback = st.radio(
+                "Was this response helpful?",
+                ["👍", "👎"],
+                index=None,
+                key=feedback_key,
+                horizontal=True
+            )
+            if feedback:
+                log_event("feedback", query=last_query, response=last_response, feedback=feedback)
+                st.session_state['pending_feedback'] = None  # Clear feedback
+                
 
-with response_container:
-    if st.session_state['responses']:
-        for i in range(len(st.session_state['responses'])):
-            message(st.session_state['responses'][i], 
-                   avatar_style="no-avatar",
-                   key=str(i))
-            if i < len(st.session_state['requests']):
-                message(st.session_state["requests"][i], 
-                       is_user=True,
-                       avatar_style="no-avatar",
-                       key=str(i) + '_user')
-        
-        # Show feedback only after the latest assistant message
-        last_idx = len(st.session_state['responses']) - 1
-        last_response = st.session_state['responses'][last_idx]
-        last_query = st.session_state['requests'][last_idx] if last_idx < len(st.session_state['requests']) else ""
+    def get_response(user_input: str) -> str:
+        if not user_input:
+            return "Please enter a valid question."
+        conversation_string = get_conversation_string()
+        refined_query = query_refiner(client, conversation_string, user_input)
+        context = find_match(vectorstore, refined_query)
+        response = conversation.predict(input=f"Context:\n {context} \n\n Query:\n{user_input}")
+        return response
 
-        feedback_key = f"feedback_{last_idx}"
-        feedback = st.radio(
-            "Was this response helpful?",
-            ["👍", "👎"],
-            index=None,
-            key=feedback_key,
-            horizontal=True
+if page == "monitor":
+    # Load dashboard password
+    if "monitor_authenticated" not in st.session_state:
+        password = st.sidebar.text_input("🔐 Enter dashboard password", type="password")
+        if password == DASHBOARD_PASSWORD:
+            st.session_state["monitor_authenticated"] = True
+        elif password:
+            st.warning("Access denied.")
+            st.stop()
+
+    if not st.session_state.get("monitor_authenticated", False):
+        st.stop()
+
+    st_autorefresh(interval=5000, limit=None, key="monitor-refresh")
+
+    rows = get_all_logs()
+    if not rows:
+        st.warning("⚠️ No log data found.")
+        st.stop()
+
+    df = pd.DataFrame(rows, columns=["id", "timestamp", "event", "query", "response", "feedback", "response_time"])
+    df["timestamp"] = pd.to_datetime(df["timestamp"])
+
+    st.subheader("📌 Key Metrics")
+    col1, col2, col3, col4 = st.columns(4)
+
+    with col1:
+        st.metric("✅ Answered", df[df.event == "answered"].shape[0])
+        st.metric("❌ Irrelevant", df[df.event == "out_of_scope"].shape[0])
+    with col2:
+        st.metric("✅ RAG Success", df[df.event == "rag_success"].shape[0])
+        st.metric("👤 Advisor Requests", df[df.event == "advisor_request"].shape[0])
+    with col3:
+        st.metric("👍 Positive Feedback", df[df.feedback == "👍"].shape[0])
+        st.metric("👎 Negative Feedback", df[df.feedback == "👎"].shape[0])
+    with col4:
+        avg_response_time = df["response_time"].dropna().mean()
+        st.metric("⏱️ Avg Time", f"{avg_response_time:.2f} s")
+
+    st.markdown("---")
+    st.subheader("📈 Trends Over Time")
+
+    df = df.dropna(subset=["timestamp"])
+    if not df.empty:
+        answered_over_time = df[df.event == "answered"].groupby(pd.Grouper(key="timestamp", freq="15min")).size().reset_index(name="count")
+        out_of_scope_over_time = df[df.event == "out_of_scope"].groupby(pd.Grouper(key="timestamp", freq="15min")).size().reset_index(name="count")
+        advisor_request_over_time = df[df.event == "advisor_request"].groupby(pd.Grouper(key="timestamp", freq="15min")).size().reset_index(name="count")
+        feedback_over_time = df[df.event == "feedback"].groupby([pd.Grouper(key="timestamp", freq="15min"), "feedback"]).size().unstack(fill_value=0).reset_index()
+        response_times = df.dropna(subset=["response_time"])
+
+        st.altair_chart(
+            alt.Chart(answered_over_time).mark_line(point=True).encode(
+                x="timestamp:T", y="count:Q", tooltip=["timestamp:T", "count:Q"]
+            ).properties(title="✅ Answers Over Time").interactive(),
+            use_container_width=True
         )
-        if feedback:
-            log_event("feedback", query=last_query, response=last_response, feedback=feedback)
-            st.session_state['pending_feedback'] = None  # Clear feedback
-            
 
-def get_response(user_input: str) -> str:
-    if not user_input:
-        return "Please enter a valid question."
-    conversation_string = get_conversation_string()
-    refined_query = query_refiner(client, conversation_string, user_input)
-    context = find_match(vectorstore, refined_query)
-    response = conversation.predict(input=f"Context:\n {context} \n\n Query:\n{user_input}")
-    return response
+        st.altair_chart(
+            alt.Chart(out_of_scope_over_time).mark_line(point=True, color="orange").encode(
+                x="timestamp:T", y="count:Q", tooltip=["timestamp:T", "count:Q"]
+            ).properties(title="❌ Irrelevant and Dismissed Queries Over Time").interactive(),
+            use_container_width=True
+        )
+        
+        st.altair_chart(
+            alt.Chart(advisor_request_over_time).mark_line(point=True, color="green").encode(
+                x="timestamp:T", y="count:Q", tooltip=["timestamp:T", "count:Q"]
+            ).properties(title="👤 Advisor Requests Over Time").interactive(),
+            use_container_width=True
+        )
+
+        feedback_melted = feedback_over_time.melt(id_vars="timestamp", var_name="Feedback", value_name="Count")
+        st.altair_chart(
+            alt.Chart(feedback_melted).mark_bar().encode(
+                x="timestamp:T", y="Count:Q", color="Feedback:N", tooltip=["timestamp:T", "Feedback:N", "Count:Q"]
+            ).properties(title="👍👎 Feedback Over Time").interactive(),
+            use_container_width=True
+        )
+
+        if not response_times.empty:
+            st.line_chart(response_times.set_index("timestamp")["response_time"].rename("Response Time (s)"))
+
+    st.markdown("---")
+    st.subheader("📄 Explore Logs")
+    st.dataframe(df.sort_values("timestamp", ascending=False), use_container_width=True)
+
+    # Download CSV
+    csv_buffer = StringIO()
+    df.to_csv(csv_buffer, index=False)
+    st.download_button("📥 Download Logs as CSV", data=csv_buffer.getvalue(), file_name="fiscozen_chatbot_logs.csv", mime="text/csv")

--- a/main.py
+++ b/main.py
@@ -39,8 +39,27 @@ st.markdown("""
 
 st.subheader("Fiscozen")
 # Get API keys from environment variables
+
+# Load environment variables
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 PINECONE_API_KEY = os.getenv("PINECONE_API_KEY")
+DASHBOARD_PASSWORD = os.getenv("DASHBOARD_PASSWORD")
+
+# Try to load from `.env` for local development
+if not OPENAI_API_KEY or not PINECONE_API_KEY:
+    if os.path.exists(".env"):
+        from dotenv import load_dotenv
+        load_dotenv()
+        OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+        PINECONE_API_KEY = os.getenv("PINECONE_API_KEY")
+        DASHBOARD_PASSWORD = os.getenv("DASHBOARD_PASSWORD")
+
+# Try loading from Streamlit secrets if still missing
+if not OPENAI_API_KEY or not PINECONE_API_KEY:
+    if "OPENAI_API_KEY" in st.secrets and "PINECONE_API_KEY" in st.secrets:
+        OPENAI_API_KEY = st.secrets["OPENAI_API_KEY"]
+        PINECONE_API_KEY = st.secrets["PINECONE_API_KEY"]
+        DASHBOARD_PASSWORD = st.secrets.get("DASHBOARD_PASSWORD")
 
 if not OPENAI_API_KEY or not PINECONE_API_KEY:
     st.error("Please set up your API keys in the .env file")
@@ -111,6 +130,7 @@ with textcontainer:
     query = st.chat_input("Type here...")
     if query:
         with st.spinner("Typing..."):
+            
             conversation_string = get_conversation_string()
             refined_query = query_refiner(client, conversation_string, query)
             print("\nRefined Query:", refined_query)

--- a/monitor/__init__.py
+++ b/monitor/__init__.py
@@ -1,0 +1,3 @@
+"""
+Monitoring and analytics tools for the Fiscozen Tax Chatbot
+""" 

--- a/monitor/db_logger.py
+++ b/monitor/db_logger.py
@@ -1,0 +1,72 @@
+import sqlite3
+from datetime import datetime
+import pandas as pd
+import os
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+DB_DIR = os.path.join(BASE_DIR, "logs")
+DB_PATH = os.path.join(DB_DIR, "logs.db")
+
+def init_db():
+    try:
+        os.makedirs(DB_DIR, exist_ok=True)
+    except Exception as e:
+        print(f"Failed to create DB directory: {e}")
+        raise
+    try:
+        conn = sqlite3.connect(DB_PATH)
+        cursor = conn.cursor()
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS logs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT,
+                event TEXT,
+                query TEXT,
+                response TEXT,
+                feedback TEXT,
+                response_time REAL
+            )
+        ''')
+        conn.commit()
+        conn.close()
+    except Exception as e:
+        print(f"Failed to initialize database: {e}")
+        raise
+
+
+def log_event(event, query=None, response=None, feedback=None, response_time=None):
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+
+    # Safely cast response_time to float if not None
+    if response_time is not None:
+        response_time = float(response_time)
+
+    cursor.execute('''
+        INSERT INTO logs (timestamp, event, query, response, feedback, response_time)
+        VALUES (?, ?, ?, ?, ?, ?)
+    ''', (
+        datetime.now().isoformat(),
+        str(event),
+        str(query) if query else None,
+        str(response) if response else None,
+        str(feedback) if feedback else None,
+        response_time
+    ))
+    conn.commit()
+    conn.close()
+
+
+def get_all_logs():
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute('SELECT id, timestamp, event, query, response, feedback, response_time FROM logs')
+    rows = cursor.fetchall()
+    conn.close()
+    return rows
+
+def export_logs_to_csv(db_path="monitor/logs/logs.db", csv_path="monitor/logs/logs_export.csv"):
+    conn = sqlite3.connect(db_path)
+    df = pd.read_sql_query("SELECT * FROM logs", conn)
+    df.to_csv(csv_path, index=False)
+    conn.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -111,6 +111,7 @@ SQLAlchemy==2.0.32
 stack-data==0.6.3
 streamlit==1.37.1
 streamlit-authenticator==0.3.3
+streamlit-autorefresh==0.0.3
 streamlit-chat==0.1.1
 tenacity==8.5.0
 tiktoken==0.7.0


### PR DESCRIPTION
This new features allow to have:
- A monitoring page protected by a password (dont forget to update your local .env), so now there is the chat page which is default and the monitoring that can be accessed by adding /?page=monitor to the URL
-  For the monitoring page I added logs, some will be functional once the fasttext is implemented
-  I also made a change so the .env variables are correctly taken from either local or streamlit and updated the deployment to take the env variable from secrets.
- There is also now a feeback feature that shows only on the last chatbot response, the user can either leave it blank or give feedback on the response, then we would know if the chatbots responses are useful to the customer. 
- the logs are stored on sqlite and for this you will see a new folder monitor with the setup for the database (db_logger)