### PR TITLE
Enhanced Chatbot with External Knowledge APIs

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -4,6 +4,7 @@ from pinecone import Pinecone
 from langchain_pinecone import PineconeVectorStore
 import streamlit as st
 from monitor.db_logger import log_event
+import requests
 
 from ingestion.config import MODEL, INDEX, PINECONE_ENV
 
@@ -73,3 +74,98 @@ def get_conversation_string():
         conversation_string += "Human: " + st.session_state['requests'][i] + "\n"
         conversation_string += "Bot: " + st.session_state['responses'][i+1] + "\n"
     return conversation_string
+
+def fetch_external_knowledge(query):
+    """
+    Fetch relevant data from external knowledge sources based on query content.
+    Returns formatted data that can be added to the context.
+    """
+    knowledge = []
+    api_types_used = []
+    
+    # Define API endpoints
+    endpoints = {
+        "locations": "https://fizcochat.github.io/partita_iva_api/api/locations.json",
+        "professions": "https://fizcochat.github.io/partita_iva_api/api/professions.json",
+        "tax_regimes": "https://fizcochat.github.io/partita_iva_api/api/tax-regimes.json"
+    }
+    
+    # Initialize cache in session state if it doesn't exist
+    if 'api_cache' not in st.session_state:
+        st.session_state.api_cache = {}
+    
+    # Location keywords
+    locations = ["Milan", "Rome", "Florence", "Remote", "Naples", "Turin"]
+    if any(location.lower() in query.lower() for location in locations):
+        try:
+            # Use cached data if available
+            if "locations" in st.session_state.api_cache:
+                data = st.session_state.api_cache["locations"]
+            else:
+                response = requests.get(endpoints["locations"])
+                response.raise_for_status()
+                data = response.json()
+                # Cache the data
+                st.session_state.api_cache["locations"] = data
+            
+            # Find which location was mentioned
+            for location in locations:
+                if location.lower() in query.lower() and location in data:
+                    location_info = "\n".join([f"- {tip}" for tip in data[location]])
+                    knowledge.append(f"Location-specific information for {location}:\n{location_info}")
+                    api_types_used.append("locations")
+                    log_event("external_api", query=query, api_type="locations")
+        except Exception as e:
+            print(f"Error fetching location data: {e}")
+    
+    # Profession keywords
+    professions = ["Designer", "Software", "Photographer", "Digital Marketer", "Yoga", "Translator"]
+    if any(profession.lower() in query.lower() for profession in professions):
+        try:
+            # Use cached data if available
+            if "professions" in st.session_state.api_cache:
+                data = st.session_state.api_cache["professions"]
+            else:
+                response = requests.get(endpoints["professions"])
+                response.raise_for_status()
+                data = response.json()
+                # Cache the data
+                st.session_state.api_cache["professions"] = data
+            
+            # Find which profession was mentioned
+            for key, profession in [("Freelance Designer", "Designer"), ("Software Consultant", "Software"), 
+                               ("Photographer", "Photographer"), ("Digital Marketer", "Digital Marketer"),
+                               ("Yoga Instructor", "Yoga"), ("Translator", "Translator")]:
+                if profession.lower() in query.lower() and key in data:
+                    profession_info = "\n".join([f"- {tip}" for tip in data[key]])
+                    knowledge.append(f"Profession-specific information for {key}:\n{profession_info}")
+                    api_types_used.append("professions")
+                    log_event("external_api", query=query, api_type="professions")
+        except Exception as e:
+            print(f"Error fetching profession data: {e}")
+    
+    # Tax regime keywords
+    tax_regimes = ["Forfettario", "Ordinario", "Regime dei Minimi", "Regime Ordinario Semplificato"]
+    if any(regime.lower() in query.lower() for regime in tax_regimes):
+        try:
+            # Use cached data if available
+            if "tax_regimes" in st.session_state.api_cache:
+                data = st.session_state.api_cache["tax_regimes"]
+            else:
+                response = requests.get(endpoints["tax_regimes"])
+                response.raise_for_status()
+                data = response.json()
+                # Cache the data
+                st.session_state.api_cache["tax_regimes"] = data
+            
+            # Find which tax regime was mentioned
+            for regime in tax_regimes:
+                if regime.lower() in query.lower() and regime in data:
+                    regime_info = "\n".join([f"- {tip}" for tip in data[regime]])
+                    knowledge.append(f"Tax regime information for {regime}:\n{regime_info}")
+                    api_types_used.append("tax_regimes")
+                    log_event("external_api", query=query, api_type="tax_regimes")
+        except Exception as e:
+            print(f"Error fetching tax regime data: {e}")
+    
+    return "\n\n".join(knowledge)


### PR DESCRIPTION
As per Fiscozen request to include API calls... Added integration with location, profession, and tax regime API endpoints to provide more targeted and personalized responses to users. This enhancement allows the chatbot to automatically fetch relevant information based on query keywords without requiring changes to the core RAG system.

## Features:
- Modular implementation of external knowledge API integration
- Session-based caching to improve performance and reduce API calls
- Expanded monitoring dashboard with API usage metrics and visualization
- Support for location-specific guidance (Milan, Rome, Florence, etc.)
- Profession-specific tax advice (designers, software consultants, photographers, etc.)
- Tax regime details and requirements (Forfettario, Ordinario, etc.)

The external knowledge is seamlessly incorporated into the context provided to the LLM, maintaining the existing conversation flow while enhancing response quality for location, profession, and tax regime questions.

The mock API is hosted as static JSON files in the following GitHub repository:  
🔗 [https://fizcochat.github.io/partita_iva_api](https://fizcochat.github.io/partita_iva_api)

### Available Endpoints:
- `/api/professions.json`
- `/api/locations.json`
- `/api/tax-regimes.json`

These endpoints are publicly accessible via GitHub Pages and used by the chatbot to retrieve targeted Partita IVA guidance in real time.
